### PR TITLE
Pull updates from ubuntu-flavor-installer

### DIFF
--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -4,10 +4,10 @@ dependency_overrides:
   ubuntu_desktop_installer:
     git:
       url: https://github.com/canonical/ubuntu-desktop-installer
-      ref: 4240284b258779531aca374b9b61fc06e6e0d588
+      ref: 3cb02d67b64352f1e5f38ffd9685cdac75a53d14
       path: packages/ubuntu_desktop_installer
   ubuntu_wizard:
     git:
       url: https://github.com/canonical/ubuntu-desktop-installer
-      ref: 4240284b258779531aca374b9b61fc06e6e0d588
+      ref: 3cb02d67b64352f1e5f38ffd9685cdac75a53d14
       path: packages/ubuntu_wizard

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,6 +115,7 @@ parts:
       - libpython3.8-minimal
       - python3-apport
       - python3-requests-unixsocket
+      - python3-pyroute2
       - python3-pyudev
       - python3-systemd
       - python3-urwid
@@ -127,7 +128,7 @@ parts:
 
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.7.0
+    source-tag: 3.7.6
     source-depth: 1
     plugin: nil
     override-build: |


### PR DESCRIPTION
NOTE: The design of the _Try or install_ screen has changed.

The assets to customize the logo for light and dark themes:
- `assets/try_or_install/logo-light.svg`
- `assets/try_or_install/logo-dark.svg`

![image](https://user-images.githubusercontent.com/140617/222781646-5a2e05e5-8419-425b-a4f0-2a26e729d6bb.png)

- https://github.com/canonical/ubuntu-desktop-installer/pull/1514