### PR TITLE
chore: pin provision submodule to archive/main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ubuntu-desktop-provision"]
 	path = vendor/ubuntu-desktop-provision
 	url = https://github.com/canonical/ubuntu-desktop-provision.git
+	branch = archive/main


### PR DESCRIPTION
Switch to the archive main whilst the new provisioning workflow is being worked on